### PR TITLE
Removing unused .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,0 @@
-node_modules/


### PR DESCRIPTION
This pull request:
- removes the .dockerignore file 