### PR TITLE
Storge handling feature from phantomas 2.4.0

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -24,6 +24,8 @@ var cli = meow({
         '  --allow-domain       Only allow requests to given (comma-separated) domains.',
         '  --no-externals       Block all domains except the main one.',
         '  --reporter           The output format: "json" or "xml". Default is "json".',
+        '  --local-storage      Ability to set a local storage, key-value pairs (e.g. "bar=foo;domain=url")',
+        '  --session-storage    Ability to set a session storage, key-value pairs (e.g. "bar=foo;domain=url")',
         ''
     ].join('\n'),
     pkg: require('../package.json')
@@ -74,6 +76,10 @@ options.authPass = cli.flags.authPass || null;
 options.blockDomain =  cli.flags.blockDomain || null;
 options.allowDomain =  cli.flags.allowDomain || null;
 options.noExternals =  cli.flags.noExternals || null;
+
+// Storage injection
+options.localStorage = cli.flags.localStorage;
+options.sessionStorage = cli.flags.sessionStorage;
 
 // Output format
 if (cli.flags.reporter && cli.flags.reporter !== 'json' && cli.flags.reporter !== 'xml') {

--- a/lib/tools/phantomas/phantomasWrapper.js
+++ b/lib/tools/phantomas/phantomasWrapper.js
@@ -43,6 +43,8 @@ var PhantomasWrapper = function() {
             'block-domain': task.options.blockDomain,
             'allow-domain': task.options.allowDomain,
             'no-externals': task.options.noExternals,
+            'local-storage': task.options.localStorage,
+            'session-storage': task.options.sessionStorage,
 
             // Mandatory
             'analyze-css': true,

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "md5": "2.2.1",
     "meow": "5.0.0",
     "parse-color": "1.0.0",
-    "phantomas": "2.2.0",
+    "phantomas": "2.4.0",
     "q": "1.5.1",
     "request": "2.88.0",
     "ttf2woff2": "4.0.1",


### PR DESCRIPTION
Hello guys,

we have a small contribution for you, which depend on the newly released phantomas v2.4.0.

In this release the ability to inject a local-/sessionstorage has been added to circumvent possible authentication pages while testing.

We want to use this functionality in our testing pipeline and would appreciate if you could review the changes and hopefully bringing this in a future release.
